### PR TITLE
Bnb-699 | Cors proxy issue file type

### DIFF
--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -11,5 +11,6 @@ pipeline:
       access: public
 when:
   branch: master
-  event: push
+  event: tag
+  ref: refs/tags/v*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "app-validation-tool",
-  "version": "1.0.27",
+  "name": "@lblod/lib-decision-validation",
+  "version": "1.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "app-validation-tool",
-      "version": "1.0.27",
+      "name": "@lblod/lib-decision-validation",
+      "version": "1.0.33",
       "license": "MIT",
       "dependencies": {
         "@comunica/actor-http-proxy": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lblod/lib-decision-validation",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "publishConfig": {
     "access": "public"
   },

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -10,8 +10,6 @@ export * from './queries';
 
 const engine = new QueryEngine();
 
-const defaultProxy = 'https://corsproxy.io/?';
-
 export async function getPublicationFromFileContent(content: string): Promise<Bindings[]> {
   const bindingsStream: BindingsStream = await engine.queryBindings(
     `
@@ -35,7 +33,7 @@ export async function getPublicationFromFileContent(content: string): Promise<Bi
   return bindingsStream.toArray();
 }
 
-export async function fetchDocument(publicationLink: string, proxy: string = defaultProxy): Promise<Bindings[]> {
+export async function fetchDocument(publicationLink: string, proxy: string): Promise<Bindings[]> {
   const bindingsStream: BindingsStream = await engine.queryBindings(
     `
         SELECT ?s ?p ?o 


### PR DESCRIPTION
When adding this link into the validation tool we get a toaster message that the file type is not possible. Make sure that https://www.provincieantwerpen.be/content/dam/publicaties/open-data/provincieraad/2024/2024-01-25/pr_2024-01-25.html can be validated

Remove the default proxy of an external service