### PR TITLE
Add generic validation function

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -34,7 +34,6 @@ export async function getPublicationFromFileContent(content: string): Promise<Bi
 }
 
 export async function getBindingsFromTurtleContent(content: string): Promise<Bindings[]> {
-  console.log('get bindings');
   const bindingsStream: BindingsStream = await engine.queryBindings(
     `
       SELECT ?s ?p ?o

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -33,10 +33,34 @@ export async function getPublicationFromFileContent(content: string): Promise<Bi
   return bindingsStream.toArray();
 }
 
+export async function getBindingsFromTurtleContent(content: string): Promise<Bindings[]> {
+  console.log('get bindings');
+  const bindingsStream: BindingsStream = await engine.queryBindings(
+    `
+      SELECT ?s ?p ?o
+      WHERE {
+        ?s ?p ?o .
+      }
+    `,
+    {
+      sources: [
+        {
+          type: 'serialized',
+          value: content,
+          mediaType: 'text/turtle',
+          baseIRI: 'http://example.org/',
+        },
+      ],
+    },
+  );
+
+  return bindingsStream.toArray();
+}
+
 export async function fetchDocument(publicationLink: string, proxy?: string): Promise<Bindings[]> {
   let proxyHandler;
   if (proxy) proxyHandler = new ProxyHandlerStatic(proxy);
-  
+
   const bindingsStream: BindingsStream = await engine.queryBindings(
     `
         SELECT ?s ?p ?o 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -237,6 +237,21 @@ export async function validatePublication(
   } as ValidatedPublication;
 }
 
+export async function validateDocument(rdfDocument: Bindings[], blueprint: Bindings[]): Promise<ValidatedSubject[]> {
+  const parsedSubjects = parsePublication(rdfDocument);
+  BLUEPRINT = blueprint;
+
+  let validatedSubjects: ValidatedSubject[] = [];
+  parsedSubjects.forEach((subject) => {
+    if (subject) {
+      const resultSubjects = validateSubject(subject);
+      validatedSubjects = validatedSubjects.concat(resultSubjects);
+    }
+  });
+
+  return validatedSubjects;
+}
+
 /* function to validate the properties of a subject
   param:
   - subject: subject to be validated

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -237,9 +237,10 @@ export async function validatePublication(
   } as ValidatedPublication;
 }
 
-export async function validateDocument(rdfDocument: Bindings[], blueprint: Bindings[]): Promise<ValidatedSubject[]> {
+export async function validateDocument(rdfDocument: Bindings[], blueprint: Bindings[]): Promise<ValidatedPublication> {
   const parsedSubjects = parsePublication(rdfDocument);
   BLUEPRINT = blueprint;
+  EXAMPLE = [];
 
   let validatedSubjects: ValidatedSubject[] = [];
   parsedSubjects.forEach((subject) => {
@@ -249,7 +250,10 @@ export async function validateDocument(rdfDocument: Bindings[], blueprint: Bindi
     }
   });
 
-  return validatedSubjects;
+  return {
+    classes: await postProcess(validatedSubjects),
+    maturity: FOUND_MATURITY,
+  } as ValidatedPublication;
 }
 
 /* function to validate the properties of a subject
@@ -486,6 +490,8 @@ async function postProcess(validatedSubjects: ValidatedSubject[]): Promise<Class
       objects,
     });
   });
-  const result: ClassCollection[] = await enrichClassCollectionsWithExample(classes, BLUEPRINT, EXAMPLE);
+  const result: ClassCollection[] = EXAMPLE?.length
+    ? await enrichClassCollectionsWithExample(classes, BLUEPRINT, EXAMPLE)
+    : classes;
   return result;
 }

--- a/tests/data/genericTestData.ts
+++ b/tests/data/genericTestData.ts
@@ -1,0 +1,37 @@
+export const genericExampleData: string = `
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<http://example.org/subject1> rdf:type foaf:Person ;
+                              foaf:name "John Doe" ;
+                              foaf:age "30" .
+
+<http://example.org/subject2> rdf:type foaf:Person ;
+                              foaf:name "Jane Doe" .
+
+# Invalid person (missing foaf:name)
+<http://example.org/subject3> rdf:type foaf:Person ;
+                              foaf:age "25" .
+`;
+
+export const genericExampleBlueprint: string = `
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/PersonShape>
+  a sh:NodeShape ;
+  sh:targetClass foaf:Person ;
+
+  sh:property [
+    sh:path foaf:name ;
+    sh:datatype xsd:string ;
+    sh:minCount 1 ;  # Must have at least one foaf:name
+  ] ;
+
+  sh:property [
+    sh:path foaf:age ;
+    sh:datatype xsd:string ;
+    sh:maxCount 1 ;  # Can have at most one foaf:age
+  ] .
+`;

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
 
+import {inspect} from 'util';
+
 import { Bindings } from '@comunica/types';
 
 import HttpRequestMock from 'http-request-mock';
@@ -250,7 +252,8 @@ describe('As a vendor, I want the tool to automatically determine the type of th
     const blueprint: Bindings[] = await getBindingsFromTurtleContent(genericExampleBlueprint);
 
     const actual = await validateDocument(document, blueprint);
-    console.log(actual);
+    
+    console.log(inspect(actual, { depth: null, colors: true }));
   });
 
   test(

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -46,6 +46,7 @@ import { genericExampleBlueprint, genericExampleData } from './data/genericTestD
 import { getDOMfromString, getStoreFromSPOBindings, runQueryOverStore } from '../src/utils';
 import { ensureDirectoryExistence } from '../src/node-utils';
 import { getHTMLExampleOfDocumentType } from 'lib-decision-shapes';
+import { ValidatedProperty } from '../src/types';
 
 const MILLISECONDS = 7000;
 
@@ -247,15 +248,6 @@ describe('As a vendor, I want the tool to automatically determine the type of th
     fs.writeFileSync('./logs/agenda3.json', `${JSON.stringify(actual)}`);
   });
 
-  test('Validate generic document', async () => {
-    const document: Bindings[] = await getBindingsFromTurtleContent(genericExampleData);
-    const blueprint: Bindings[] = await getBindingsFromTurtleContent(genericExampleBlueprint);
-
-    const actual = await validateDocument(document, blueprint);
-    
-    console.log(inspect(actual, { depth: null, colors: true }));
-  });
-
   test(
     'Validate Notulen',
     async () => {
@@ -284,6 +276,29 @@ describe('As a vendor, I want the tool to automatically determine the type of th
     MILLISECONDS * 10,
   );
 
+  test('Validate generic document', async () => {
+    const document: Bindings[] = await getBindingsFromTurtleContent(genericExampleData);
+    const blueprint: Bindings[] = await getBindingsFromTurtleContent(genericExampleBlueprint);
+
+    const validationReport = await validateDocument(document, blueprint);
+
+    const personClass = validationReport.classes.find((item) => item.classURI === 'http://xmlns.com/foaf/0.1/Person');
+
+    const subject3 = validationReport.classes[0].objects.find((obj) => obj.uri === 'http://example.org/subject3');
+
+    const nameProperty = subject3?.properties.find((prop) => prop.path === 'http://xmlns.com/foaf/0.1/name') as
+      | ValidatedProperty
+      | undefined;
+
+    const ageProperty = subject3?.properties.find((prop) => prop.path === 'http://xmlns.com/foaf/0.1/age') as
+      | ValidatedProperty
+      | undefined;
+
+    expect(personClass?.objects.length).toBe(3);
+    expect(nameProperty?.valid).toBe(false);
+    expect(ageProperty?.valid).toBe(true);
+    expect(ageProperty?.valid).toBe(true);
+  });
 
 });
 

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -4,13 +4,15 @@ import { Bindings } from '@comunica/types';
 
 import HttpRequestMock from 'http-request-mock';
 
-import { determineDocumentType, validatePublication } from '../src/validation';
+import { determineDocumentType, validatePublication, validateDocument } from '../src/validation';
+
 import {
   fetchDocument,
   getBlueprintOfDocumentType,
   getExampleOfDocumentType,
   getExampleURLOfDocumentType,
   getPublicationFromFileContent,
+  getBindingsFromTurtleContent,
 } from '../src/queries';
 
 import { Store, Quad, Term } from 'n3';
@@ -36,6 +38,8 @@ import {
   TESTHTMLSTRING,
   TESTSTRING2,
 } from './data/testData';
+
+import { genericExampleBlueprint, genericExampleData } from './data/genericTestData';
 
 import { getDOMfromString, getStoreFromSPOBindings, runQueryOverStore } from '../src/utils';
 import { ensureDirectoryExistence } from '../src/node-utils';
@@ -239,6 +243,14 @@ describe('As a vendor, I want the tool to automatically determine the type of th
 
       const actual = await validatePublication(publication, blueprint, example);
     fs.writeFileSync('./logs/agenda3.json', `${JSON.stringify(actual)}`);
+  });
+
+  test('Validate generic document', async () => {
+    const document: Bindings[] = await getBindingsFromTurtleContent(genericExampleData);
+    const blueprint: Bindings[] = await getBindingsFromTurtleContent(genericExampleBlueprint);
+
+    const actual = await validateDocument(document, blueprint);
+    console.log(actual);
   });
 
   test(


### PR DESCRIPTION
BNB-768

The validateDocument function takes in any RDF document and any blueprint (shacl shapes), and returns the validation results as a ValidatedPublication.
A test was added with some 'general' mock data.